### PR TITLE
allow closing watch window with right click inside map view

### DIFF
--- a/src/wui/watchwindow.cc
+++ b/src/wui/watchwindow.cc
@@ -18,8 +18,8 @@
 
 #include "wui/watchwindow.h"
 
-#include <set>
 #include <SDL_timer.h>
+#include <set>
 
 #include "base/i18n.h"
 #include "base/macros.h"

--- a/src/wui/watchwindow.cc
+++ b/src/wui/watchwindow.cc
@@ -18,8 +18,9 @@
 
 #include "wui/watchwindow.h"
 
-#include <SDL_timer.h>
 #include <set>
+
+#include <SDL_timer.h>
 
 #include "base/i18n.h"
 #include "base/macros.h"

--- a/src/wui/watchwindow.cc
+++ b/src/wui/watchwindow.cc
@@ -348,7 +348,7 @@ bool WatchWindow::WatchWindowMapView::handle_mousepress(uint8_t btn, int32_t x, 
 bool WatchWindow::WatchWindowMapView::handle_mouserelease(const uint8_t btn, int32_t x, int32_t y) {
 	if (btn == SDL_BUTTON_RIGHT && is_dragging()) {
 		if (!view_moved_) {
-			constexpr uint32_t kMaxClickDuration = 1000;
+			constexpr uint32_t kMaxClickDuration = 500;
 			const uint32_t release_time = SDL_GetTicks();
 			if (release_time > dragging_start_time_ &&
 			    release_time - dragging_start_time_ < kMaxClickDuration &&

--- a/src/wui/watchwindow.cc
+++ b/src/wui/watchwindow.cc
@@ -63,8 +63,7 @@ Widelands::Game& WatchWindow::game() const {
 }
 
 WatchWindow::WatchWindowMapView::WatchWindowMapView(WatchWindow* parent, const Widelands::Map& map)
-   : MapView(parent, map, 0, 0, 200, 166),
-     parent_window_(parent) {
+   : MapView(parent, map, 0, 0, 200, 166), parent_window_(parent) {
 }
 
 WatchWindow::WatchWindow(InteractiveGameBase& parent,
@@ -346,8 +345,7 @@ bool WatchWindow::WatchWindowMapView::handle_mousepress(uint8_t btn, int32_t x, 
 	}
 	return MapView::handle_mousepress(btn, x, y);
 }
-bool WatchWindow::WatchWindowMapView::handle_mouserelease(
-   const uint8_t btn, int32_t x, int32_t y) {
+bool WatchWindow::WatchWindowMapView::handle_mouserelease(const uint8_t btn, int32_t x, int32_t y) {
 	if (btn == SDL_BUTTON_RIGHT && is_dragging()) {
 		if (!view_moved_) {
 			constexpr uint32_t kMaxClickDuration = 1000;

--- a/src/wui/watchwindow.cc
+++ b/src/wui/watchwindow.cc
@@ -19,6 +19,7 @@
 #include "wui/watchwindow.h"
 
 #include <set>
+#include <SDL_timer.h>
 
 #include "base/i18n.h"
 #include "base/macros.h"
@@ -60,6 +61,11 @@ Widelands::Game& WatchWindow::game() const {
 	return parent_.game();
 }
 
+WatchWindow::WatchWindowMapView::WatchWindowMapView(WatchWindow* parent, const Widelands::Map& map)
+   : MapView(parent, map, 0, 0, 200, 166),
+     parent_window_(parent) {
+}
+
 WatchWindow::WatchWindow(InteractiveGameBase& parent,
                          const std::string& name,
                          uint16_t const id,
@@ -78,7 +84,7 @@ WatchWindow::WatchWindow(InteractiveGameBase& parent,
                       h,
                       _("Watch")),
      parent_(parent),
-     map_view_(this, game().map(), 0, 0, 200, 166),
+     map_view_(this, game().map()),
      last_visit_(game().get_gametime()),
      single_window_(init_single_window),
      id_(id) {
@@ -331,6 +337,40 @@ void WatchWindow::close_cur_view() {
 	toggle_buttons();
 }
 
+/* Allow closing by right click on mapview */
+bool WatchWindow::WatchWindowMapView::handle_mousepress(uint8_t btn, int32_t x, int32_t y) {
+	if (btn == SDL_BUTTON_RIGHT) {
+		view_moved_ = false;
+		dragging_start_time_ = SDL_GetTicks();
+	}
+	return MapView::handle_mousepress(btn, x, y);
+}
+bool WatchWindow::WatchWindowMapView::handle_mouserelease(
+   const uint8_t btn, int32_t x, int32_t y) {
+	if (btn == SDL_BUTTON_RIGHT && is_dragging()) {
+		if (!view_moved_) {
+			constexpr uint32_t kMaxClickDuration = 1000;
+			const uint32_t release_time = SDL_GetTicks();
+			if (release_time > dragging_start_time_ &&
+			    release_time - dragging_start_time_ < kMaxClickDuration &&
+			    !parent_window_->is_pinned()) {
+				parent_window_->close_cur_view();
+			}
+		} else {
+			view_moved_ = false;
+		}
+	}
+	return MapView::handle_mouserelease(btn, x, y);
+}
+bool WatchWindow::WatchWindowMapView::handle_mousemove(
+   uint8_t state, int32_t x, int32_t y, int32_t xdiff, int32_t ydiff) {
+	if ((state & SDL_BUTTON(SDL_BUTTON_RIGHT)) != 0) {
+		view_moved_ = true;
+	}
+	return MapView::handle_mousemove(state, x, y, xdiff, ydiff);
+}
+
+/***** Saving and loading *****/
 constexpr uint16_t kCurrentPacketVersion = 1;
 UI::Window& WatchWindow::load(FileRead& fr, InteractiveBase& ib, Widelands::MapObjectLoader& mol) {
 	try {

--- a/src/wui/watchwindow.h
+++ b/src/wui/watchwindow.h
@@ -60,6 +60,20 @@ struct WatchWindow : public UI::UniqueWindow {
 private:
 	static constexpr size_t kViews = 5;
 
+	// Specialization of MapView
+	class WatchWindowMapView : public MapView {
+	public:
+		WatchWindowMapView(WatchWindow* parent, const Widelands::Map& map);
+		bool handle_mousepress(uint8_t btn, int32_t x, int32_t y) override;
+		bool handle_mouserelease(uint8_t btn, int32_t x, int32_t y) override;
+		bool handle_mousemove(
+		   uint8_t state, int32_t x, int32_t y, int32_t xdiff, int32_t ydiff) override;
+	private:
+		WatchWindow* parent_window_;
+		bool view_moved_{false};
+		uint32_t dragging_start_time_{0};
+	};
+
 	// Holds information for a view
 	struct View {
 		MapView::View view;
@@ -82,7 +96,7 @@ private:
 	void set_current_view(uint8_t idx, bool save_previous = true);
 
 	InteractiveGameBase& parent_;
-	MapView map_view_;
+	WatchWindowMapView map_view_;
 	Time last_visit_;
 	bool single_window_;
 	uint8_t cur_index_{0U};

--- a/src/wui/watchwindow.h
+++ b/src/wui/watchwindow.h
@@ -66,8 +66,8 @@ private:
 		WatchWindowMapView(WatchWindow* parent, const Widelands::Map& map);
 		bool handle_mousepress(uint8_t btn, int32_t x, int32_t y) override;
 		bool handle_mouserelease(uint8_t btn, int32_t x, int32_t y) override;
-		bool handle_mousemove(
-		   uint8_t state, int32_t x, int32_t y, int32_t xdiff, int32_t ydiff) override;
+		bool
+		handle_mousemove(uint8_t state, int32_t x, int32_t y, int32_t xdiff, int32_t ydiff) override;
 	private:
 		WatchWindow* parent_window_;
 		bool view_moved_{false};


### PR DESCRIPTION
**Type of change**
New feature

**New behavior**
Right-clicking inside watch window closes it, while it is still possible to right-drag the mapview

**Possible regressions**
Watch window map view issues

**Additional context**
Re: https://github.com/widelands/widelands/pull/5820#issuecomment-1487355693